### PR TITLE
Added support for simulated annealing and microcanonical updates

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -1,6 +1,6 @@
 name: Run tests
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   test:

--- a/src/InteractionMatrix.jl
+++ b/src/InteractionMatrix.jl
@@ -19,3 +19,11 @@ function InteractionMatrix(M::T) where T<:AbstractMatrix
     m = InteractionMatrix(M[1,1], M[1,2], M[1,3], M[2,1], M[2,2], M[2,3], M[3,1], M[3,2], M[3,3])
     return m
 end
+
+function Base.:*(M::SpinMC.InteractionMatrix, s)
+    return ((M.m11 * s[1] + M.m12 * s[2] + M.m13 * s[3]) , (M.m21 * s[1] + M.m22 * s[2] + M.m23 * s[3]) , (M.m31 * s[1] + M.m32 * s[2] + M.m33 * s[3]))
+end
+
+function Base.:*(s,M::SpinMC.InteractionMatrix)
+    Base.:*(M,s)
+end

--- a/src/InteractionMatrix.jl
+++ b/src/InteractionMatrix.jl
@@ -23,7 +23,3 @@ end
 function Base.:*(M::SpinMC.InteractionMatrix, s)
     return ((M.m11 * s[1] + M.m12 * s[2] + M.m13 * s[3]) , (M.m21 * s[1] + M.m22 * s[2] + M.m23 * s[3]) , (M.m31 * s[1] + M.m32 * s[2] + M.m33 * s[3]))
 end
-
-function Base.:*(s,M::SpinMC.InteractionMatrix)
-    Base.:*(M,s)
-end

--- a/src/MonteCarlo.jl
+++ b/src/MonteCarlo.jl
@@ -128,6 +128,7 @@ function run!(mc::MonteCarlo{T}; outfile::Union{String,Nothing}=nothing, resetSp
                     for (ii,jj) in zip(mc.lattice.interactionSites[site],mc.lattice.interactionMatrices[site])
                         sj=sj .+ jj*getSpin(mc.lattice,ii)
                     end
+                    sj=sj .+ getInteractionField(mc.lattice, site)
                     #Normalize the sj vector to use for update
                     sj=sj./norm(sj)
                     newSpinState=rotSpin180(getSpin(mc.lattice,site),sj)

--- a/src/MonteCarlo.jl
+++ b/src/MonteCarlo.jl
@@ -124,15 +124,17 @@ function run!(mc::MonteCarlo{T}; outfile::Union{String,Nothing}=nothing, resetSp
         if mc.sweep % mc.microcanonicalRate == 0
             for i in 1:mc.microcanonicalPerSweep
                 for site in 1:length(mc.lattice)
-                    sj=(0.,0.,0.)
-                    for (ii,jj) in zip(mc.lattice.interactionSites[site],mc.lattice.interactionMatrices[site])
-                        sj=sj .+ jj*getSpin(mc.lattice,ii)
+                    if getInteractionOnsite(mc.lattice, site) == zeros(3,3)
+                        sj=(0.,0.,0.)
+                        for (ii,jj) in zip(mc.lattice.interactionSites[site],mc.lattice.interactionMatrices[site])
+                            sj=sj .+ jj*getSpin(mc.lattice,ii)
+                        end
+                        sj=sj .+ getInteractionField(mc.lattice, site)
+                        #Normalize the sj vector to use for update
+                        sj=sj./norm(sj)
+                        newSpinState=rotSpin180(getSpin(mc.lattice,site),sj)
+                        setSpin!(mc.lattice,site,newSpinState)
                     end
-                    sj=sj .+ getInteractionField(mc.lattice, site)
-                    #Normalize the sj vector to use for update
-                    sj=sj./norm(sj)
-                    newSpinState=rotSpin180(getSpin(mc.lattice,site),sj)
-                    setSpin!(mc.lattice,site,newSpinState)
                 end
             end
         end

--- a/src/MonteCarlo.jl
+++ b/src/MonteCarlo.jl
@@ -114,6 +114,18 @@ function run!(mc::MonteCarlo{T}; outfile::Union{String,Nothing}=nothing, resetSp
         end
         statistics.sweeps += 1
 
+        #perform microcanonical sweep
+        for site in 1:length(mc.lattice)
+            sj=(0.,0.,0.)
+            for (ii,jj) in zip(mc.lattice.interactionSites[site],mc.lattice.interactionMatrices[site])
+                sj=sj .+ jj*getSpin(mc.lattice,ii)
+            end
+            #Normalize the sj vector to use for update
+            sj=sj./norm(sj)
+            newSpinState=rotSpin180(getSpin(mc.lattice,site),sj)
+            setSpin!(mc.lattice,site,newSpinState)
+        end
+
         #perform replica exchange
         if enableMPI && mc.sweep % mc.replicaExchangeRate == 0
             #determine MPI rank to exchagne configuration with

--- a/src/Spin.jl
+++ b/src/Spin.jl
@@ -80,3 +80,9 @@ function getCorrelation(lattice::Lattice{D,N}) where {D,N}
     end
     return corr
 end
+
+function rotSpin180(s,axis)
+    x1,y1,z1=s
+    x,y,z=axis
+    return (2*x*y*y1+2*x*z*z1+x1*(2*x^2-1),2*x*x1*y+2*y*z*z1+y1*(2*y^2-1),2*x*x1*z+2*y*y1*z+z1*(2*z^2-1))
+end

--- a/src/SpinMC.jl
+++ b/src/SpinMC.jl
@@ -12,7 +12,7 @@ include("Spin.jl")
 export getEnergy, getMagnetization, getCorrelation
 
 include("MonteCarlo.jl")
-export MonteCarlo, run!, runSA
+export MonteCarlo, run!, anneal
 
 include("Helper.jl")
 include("IO.jl")

--- a/src/SpinMC.jl
+++ b/src/SpinMC.jl
@@ -12,7 +12,7 @@ include("Spin.jl")
 export getEnergy, getMagnetization, getCorrelation
 
 include("MonteCarlo.jl")
-export MonteCarlo, run!
+export MonteCarlo, run!, runSA
 
 include("Helper.jl")
 include("IO.jl")


### PR DESCRIPTION
- Added the function "runSA" for simulated annealing 
- Added micro canonical updates i.e updates that perform a 180 degree rotation of the spins with respect to the axis defined by the neighboring spins and their interaction matrices. This update keeps the energy of the configuration unchanged and thus should get accepted automatically while changing the spin as much as possible with regard to the local axis. They should help with low-temperature runs where the update rate is tiny. 
-Modified MonteCarlo struct to include "microcanonicalRate" which, similar to the replicaExchangeRate sets the interval of MC sweeps before starting a micro canonical sweep and "microcanonicalPerSweep" i.e number of micro canonical sweeps in a single MC sweep. 
- Might be a better idea to turn off microcanonical sweeps as a default by setting "microcanonicalRate" to typemax(Int) or setting "microcanonicalPerSweep" to 0 as these sweeps are mostly helpful only at low temperature.
